### PR TITLE
fix ios

### DIFF
--- a/ios/Classes/NTSListFiles.swift
+++ b/ios/Classes/NTSListFiles.swift
@@ -45,6 +45,7 @@ class NTSListFile {
                 
             }
         } else {
+            completionHandler(list)
             print("no photos to display")
         }
     }


### PR DESCRIPTION
1. Run example on simulator iPhone 11, iOS 15.0
2. On simulator stores few photos, no videos
3. Navigate on tabs

Result: no one image not loaded, because CompletionHandler not called on getPhotos when try to get .videos

4. Sorry for english